### PR TITLE
Add 'UI Card for Better Thermostat' to exceptions

### DIFF
--- a/src/swipe-navigation.ts
+++ b/src/swipe-navigation.ts
@@ -33,6 +33,8 @@ const exceptions = [
   // 💡 Please keep this list sorted alphabetically. Consider the selector as the key after removing
   // all symbols. Only consider letters and numbers.
 
+  // UI Card for Better Thermostat (https://github.com/KartoffelToby/better-thermostat-ui-card)
+  "better-thermostat-ui-card",
   // ApexCharts Card by RomRider (https://github.com/RomRider/apexcharts-card)
   "#graph-wrapper svg.apexcharts-svg",
   // 🍄 Mushroom (https://github.com/piitaya/lovelace-mushroom)


### PR DESCRIPTION
Add ['UI Card for Better Thermostat'](https://github.com/KartoffelToby/better-thermostat-ui-card) to exceptions.

When using the slider to change the temperature it activates the swipe navigation. I'm not entirely sure why this happens only to the 'Better Thermostat' and not the default. Also there is some strange behavior on the default one (swiping right works, left not), which is unrelated imo.

I recorded a short clip to demonstrate the behavior:

https://user-images.githubusercontent.com/43964592/209462382-59132f04-f13e-469e-93a9-ab65d009a848.mp4

Signed-off-by: Christos Sidiropoulos <csidirop@runbox.com>