### PR TITLE
Add android-tv-card and service-call-tile-feature slider exceptions

### DIFF
--- a/src/swipe-navigation.ts
+++ b/src/swipe-navigation.ts
@@ -64,12 +64,16 @@ const exceptions = [
   "round-slider",
   // Sankey Chart Card (https://github.com/MindFreeze/ha-sankey-chart)
   "sankey-chart",
+  // Service call tile feature slider (https://github.com/Nerwyn/service-call-tile-feature)
+  "service-call-slider",
   // Slider button card (https://github.com/mattieha/slider-button-card)
   "slider-button-card",
   // Swipe Card (https://github.com/bramkragten/swipe-card)
   "swipe-card",
   // Meteoalarm Card (https://github.com/MrBartusek/MeteoalarmCard)
   ".swiper",
+  // Android TV Card slider (https://github.com/Nerwyn/android-tv-card)
+  "remote-slider",
   // Android TV Card touchpad (https://github.com/Nerwyn/android-tv-card)
   "toucharea",
   // Lovelace Vacuum Map card (https://github.com/PiotrMachowski/lovelace-xiaomi-vacuum-map-card)


### PR DESCRIPTION
I've added input range sliders to a couple of my projects and would like to add swipe exceptions for them. Here are some screenshots of their HTML:

remote-slider
<img alt="image" src="https://github.com/zanna-37/hass-swipe-navigation/assets/43071698/0f6e61a8-7e62-41a1-a0e0-60119ffc6545">

service-call-slider
<img alt="image" src="https://github.com/zanna-37/hass-swipe-navigation/assets/43071698/29ffb687-783b-42e1-9920-8026a8df5a2e">
