### PR TITLE
Adding swipe/view indicator functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ If you want to modify the configuration, place it in the root of your dashboard 
 | swipe_amount       | number  |  `15`   | Minimum percent of screen needed to be swiped in order to navigate.                                                                                                          |
 | wrap               | boolean | `true`  | Wrap from first tab to last tab and vice versa.                                                                                                                              |
 | ~~skip_hidden~~    | boolean | `true`  | Automatically skip hidden tabs.<br>⚠️ _Setting this to `false` is deprecated and poses a security risk as it allows a user to reveal a tab they don't have access to._        |
-| indicator          | boolean | `true`  | Show the bottom slide indicator (dots).                                                                                                                                      |
+| indicator          | boolean | `false` | Show the bottom slide indicator (dots).                                                                                                                                      |
 | indicator_duration | number  | `1500`  | How long (ms) the indicator remains visible after the swipe ends. Should be at least animate_duration + indicator_resync_buffer to avoid flickering.                         |
 | indicator_resync_buffer | number | `50` | Extra buffer (ms) added to `animate_duration` before the indicator resyncs after a swipe. Increase on slower devices/themes to avoid flicker.                              |
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ If you want to modify the configuration, place it in the root of your dashboard 
 | swipe_amount       | number  |  `15`   | Minimum percent of screen needed to be swiped in order to navigate.                                                                                                          |
 | wrap               | boolean | `true`  | Wrap from first tab to last tab and vice versa.                                                                                                                              |
 | ~~skip_hidden~~    | boolean | `true`  | Automatically skip hidden tabs.<br>⚠️ _Setting this to `false` is deprecated and poses a security risk as it allows a user to reveal a tab they don't have access to._        |
+| indicator          | boolean | `true`  | Show the bottom slide indicator (dots).                                                                                                                                      |
+| indicator_duration | number  | `1500`  | How long (ms) the indicator remains visible after the swipe ends. Should be at least animate_duration + indicator_resync_buffer to avoid flickering.                         |
+| indicator_resync_buffer | number | `50` | Extra buffer (ms) added to `animate_duration` before the indicator resyncs after a swipe. Increase on slower devices/themes to avoid flicker.                              |
 
 
 **Example:**

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,7 +17,7 @@ class Config {
   private skip_tabs: readonly number[] = [];
   private swipe_amount = 0.15;
   private wrap = true;
-  private indicator = true;               // default: true
+  private indicator = false;
   private indicator_duration = 1500;      // default: 2000
   private indicator_resync_buffer = 120;    // default: 120
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,9 @@ class Config {
   private skip_tabs: readonly number[] = [];
   private swipe_amount = 0.15;
   private wrap = true;
+  private indicator = true;               // default: true
+  private indicator_duration = 1500;      // default: 2000
+  private indicator_resync_buffer = 120;    // default: 120
 
   public getAnimate(): "none" | "swipe" | "fade" | "flip" {
     return this.animate;
@@ -64,6 +67,18 @@ class Config {
 
   public getWrap(): boolean {
     return this.wrap;
+  }
+
+  public getIndicator(): boolean {
+    return this.indicator;
+  }
+
+  public getIndicatorResyncBuffer(): number {
+    return this.indicator_resync_buffer;
+  }
+
+  public getIndicatorDuration(): number {
+    return this.indicator_duration;
   }
 
 
@@ -124,6 +139,10 @@ class Config {
     }
     if (rawConfig.swipe_amount != null) { newConfig.swipe_amount = rawConfig.swipe_amount / 100.0; }
     if (rawConfig.wrap != null) { newConfig.wrap = rawConfig.wrap; }
+    
+    if (rawConfig.indicator != null) { newConfig.indicator = rawConfig.indicator; }
+    if (rawConfig.indicator_duration != null) { newConfig.indicator_duration = rawConfig.indicator_duration; }
+    if (rawConfig.indicator_resync_buffer != null) { newConfig.indicator_resync_buffer = rawConfig.indicator_resync_buffer; }
 
     return newConfig;
   }
@@ -155,7 +174,10 @@ const SwipeNavigationConfigSchema = z.object({
   skip_subviews: z.boolean().optional(),
   skip_tabs: z.coerce.string().optional(),
   swipe_amount: z.number().optional(),
-  wrap: z.boolean().optional()
+  wrap: z.boolean().optional(),
+  indicator: z.boolean().optional(),
+  indicator_duration: z.number().optional(),
+  indicator_resync_buffer: z.number().optional(),
 });
 
 type SwipeNavigationConfig = z.infer<typeof SwipeNavigationConfigSchema>;

--- a/src/swipeIndicator.ts
+++ b/src/swipeIndicator.ts
@@ -1,0 +1,219 @@
+
+import { ConfigManager } from "./configManager";
+
+class SwipeIndicator {
+  private static INDICATOR_ID = "hsn-slide-indicator";
+
+  // Typed timer IDs
+  private static fadeTid: ReturnType<typeof setTimeout> | null = null;
+  private static DurationTid: ReturnType<typeof setTimeout> | null = null;
+  private static freezeResyncTid: ReturnType<typeof setTimeout> | null = null;
+
+  private static freezeUntilTs = 0;
+  private static currentIndex: number | null = null;
+  private static activeColor: string | null = null;
+  private static inactiveColor: string | null = null;
+
+  // Enabled toggle (new name only): getIndicator()
+  private static isEnabled(): boolean {
+    const cfg = ConfigManager.getCurrentConfig() as { getIndicator?: () => boolean };
+    return cfg.getIndicator ? Boolean(cfg.getIndicator()) : true;
+  }
+
+  private static readThemeColors(): void {
+    const rootStyle = getComputedStyle(document.documentElement);
+    const primary = rootStyle.getPropertyValue("--border-neutral-quiet").trim();
+    const secondary = rootStyle.getPropertyValue("--color-text-disabled").trim();
+    SwipeIndicator.activeColor = primary.length > 0 ? primary : "rgba(255,255,255,1)";
+    SwipeIndicator.inactiveColor = secondary.length > 0 ? secondary : "rgba(255,255,255,0.5)";
+  }
+
+  // Public so resize handler can call it without hacks
+  static dotSizePx(): number {
+    const w = window.innerWidth || screen.width || 0;
+    if (w >= 1600) return 12;
+    if (w >= 1024) return 10;
+    return 8;
+  }
+
+  private static ensureIndicator(total: number): HTMLDivElement | null {
+    if (!SwipeIndicator.isEnabled()) return null;
+    if (!Number.isFinite(total) || total <= 0) return null;
+
+    if (SwipeIndicator.activeColor == null || SwipeIndicator.inactiveColor == null) {
+      SwipeIndicator.readThemeColors();
+    }
+
+    let el = document.getElementById(SwipeIndicator.INDICATOR_ID) as HTMLDivElement | null;
+    if (!el) {
+      el = document.createElement("div");
+      el.id = SwipeIndicator.INDICATOR_ID;
+      el.style.position = "fixed";
+      el.style.left = "50%";
+      el.style.bottom = "12px";
+      el.style.transform = "translateX(-50%)";
+      el.style.display = "flex";
+      el.style.alignItems = "center";
+      el.style.gap = "8px";
+      el.style.padding = "6px 10px";
+      el.style.borderRadius = "9999px";
+      el.style.background = "rgba(0,0,0,0.30)";
+      el.style.backdropFilter = "blur(2px)";
+      el.style.zIndex = "2147483647";
+      el.style.pointerEvents = "none";
+      (document.body || document.documentElement).appendChild(el);
+    }
+
+    // Normalize dot count
+    const children = Array.from(el.children);
+    const diff = total - children.length;
+    if (diff > 0) {
+      for (let i = 0; i < diff; i++) {
+        const dot = document.createElement("span");
+        dot.className = "hsn-dot";
+        const size = `${SwipeIndicator.dotSizePx()}px`;
+        dot.style.width = size;
+        dot.style.height = size;
+        dot.style.borderRadius = "50%";
+        dot.style.background = SwipeIndicator.inactiveColor!;
+        dot.style.display = "inline-block";
+        el.appendChild(dot);
+      }
+    } else if (diff < 0) {
+      for (let i = 0; i < Math.abs(diff); i++) el.lastElementChild?.remove();
+    }
+
+    // Normalize sizing (orientation / resize)
+    const sizeNow = `${SwipeIndicator.dotSizePx()}px`;
+    (Array.from(el.children) as HTMLSpanElement[]).forEach((dot) => {
+      if (dot.style.width !== sizeNow) {
+        dot.style.width = sizeNow;
+        dot.style.height = sizeNow;
+      }
+    });
+
+    // Cancel fade if re-showing
+    if (SwipeIndicator.fadeTid) {
+      clearTimeout(SwipeIndicator.fadeTid);
+      SwipeIndicator.fadeTid = null;
+    }
+    el.style.opacity = "1";
+    el.style.transition = "opacity 150ms ease";
+    return el;
+  }
+
+  private static highlight(activeIndex: number): void {
+    if (!SwipeIndicator.isEnabled()) return;
+    if (Date.now() < SwipeIndicator.freezeUntilTs) return;
+
+    const views = ConfigManager.getViews();
+    if (!views) return;
+    if (SwipeIndicator.currentIndex === activeIndex) return;
+
+    const el = SwipeIndicator.ensureIndicator(views.length);
+    if (!el) return;
+
+    const dots = Array.from(el.children) as HTMLSpanElement[];
+    dots.forEach((dot, idx) => {
+      if (idx === activeIndex) {
+        dot.style.background = SwipeIndicator.activeColor!;
+        dot.style.boxShadow = `0 0 4px ${SwipeIndicator.activeColor}`;
+        dot.style.transform = "scale(1.15)";
+      } else {
+        dot.style.background = SwipeIndicator.inactiveColor!;
+        dot.style.boxShadow = "none";
+        dot.style.transform = "scale(1)";
+      }
+    });
+    SwipeIndicator.currentIndex = activeIndex;
+  }
+
+  private static update(): void {
+    if (!SwipeIndicator.isEnabled()) return;
+    if (Date.now() < SwipeIndicator.freezeUntilTs) return;
+    const idx = ConfigManager.getCurrentViewIndex();
+    if (idx == null) return;
+    SwipeIndicator.highlight(idx);
+  }
+
+  private static removeNow(): void {
+    const el = document.getElementById(SwipeIndicator.INDICATOR_ID) as HTMLDivElement | null;
+    if (el) {
+      el.style.transition = "opacity 150ms ease";
+      el.style.opacity = "0";
+      SwipeIndicator.fadeTid = setTimeout(() => {
+        if (el && el.parentNode) el.parentNode.removeChild(el);
+        SwipeIndicator.fadeTid = null;
+        SwipeIndicator.currentIndex = null;
+      }, 160);
+    }
+  }
+
+  private static removeAfter(ms: number): void {
+    const el = document.getElementById(SwipeIndicator.INDICATOR_ID) as HTMLDivElement | null;
+    if (!el) return;
+    if (SwipeIndicator.DurationTid) {
+      clearTimeout(SwipeIndicator.DurationTid);
+      SwipeIndicator.DurationTid = null;
+    }
+    SwipeIndicator.DurationTid = setTimeout(() => {
+      SwipeIndicator.DurationTid = null;
+      SwipeIndicator.removeNow();
+    }, Math.max(0, ms));
+  }
+
+  private static freezeAndResync(ms: number): void {
+    const delay = Math.max(0, ms);
+    SwipeIndicator.freezeUntilTs = Date.now() + delay;
+    if (SwipeIndicator.freezeResyncTid) {
+      clearTimeout(SwipeIndicator.freezeResyncTid);
+      SwipeIndicator.freezeResyncTid = null;
+    }
+    SwipeIndicator.freezeResyncTid = setTimeout(() => {
+      SwipeIndicator.freezeResyncTid = null;
+      SwipeIndicator.freezeUntilTs = 0;
+      SwipeIndicator.update();
+    }, delay);
+  }
+
+  static onPointerStart(): void {
+    if (SwipeIndicator.DurationTid) {
+      clearTimeout(SwipeIndicator.DurationTid);
+      SwipeIndicator.DurationTid = null;
+    }
+    SwipeIndicator.update();
+  }
+
+  static onPointerMove(): void {
+    SwipeIndicator.update();
+  }
+
+  static onPointerEnd(): void {
+    const cfg = ConfigManager.getCurrentConfig() as {
+      getAnimateDuration: () => number;
+      getIndicatorResyncBuffer?: () => number;
+      getIndicatorDuration?: () => number;
+    };
+    const animationDuration = cfg.getAnimateDuration();
+    const buffer = cfg.getIndicatorResyncBuffer ? cfg.getIndicatorResyncBuffer() : 50;
+    const indicatorDuration = cfg.getIndicatorDuration ? cfg.getIndicatorDuration() : 1500;
+
+    SwipeIndicator.freezeAndResync(animationDuration + buffer);
+    SwipeIndicator.removeAfter(indicatorDuration);
+  }
+}
+
+// Normalize sizes on resize automatically
+window.addEventListener("resize", () => {
+  const el = document.getElementById("hsn-slide-indicator") as HTMLDivElement | null;
+  if (!el) return;
+  const sizeNow = `${SwipeIndicator.dotSizePx()}px`;
+  (Array.from(el.children) as HTMLSpanElement[]).forEach((dot) => {
+    if (dot.style.width !== sizeNow) {
+      dot.style.width = sizeNow;
+      dot.style.height = sizeNow;
+    }
+  });
+});
+
+export { SwipeIndicator };

--- a/src/swipeManager.ts
+++ b/src/swipeManager.ts
@@ -9,6 +9,7 @@ import {
   scopedExceptions,
   anyExceptionSelector,
 } from "./swipeExceptions";
+import { SwipeIndicator } from "./swipeIndicator";
 
 // Cap on how many classes reach the logs, so that a single debug line stays
 // readable when an element stacks a long list of them.
@@ -204,9 +205,11 @@ class SwipeManager {
       const eventCheck/*: never*/ = event; // Firefox doesn't always set TouchEvent type
       throw new Error(`Unhandled case: ${eventCheck}`);
     }
+    SwipeIndicator.onPointerStart();
   }
 
   static #handlePointerMove(event: TouchEvent | MouseEvent) {
+    SwipeIndicator.onPointerMove();
     if (this.#xDown && this.#yDown) {
       if (window.TouchEvent != null && event instanceof TouchEvent) {
         this.#xDiff = this.#xDown - event.touches[0].clientX;
@@ -275,6 +278,7 @@ class SwipeManager {
       }
     }
     this.#xDown = this.#yDown = this.#xDiff = this.#yDiff = null;
+    SwipeIndicator.onPointerEnd();
   }
 
   static #getNextViewName(directionLeft: boolean): string | null {

--- a/tests/dashboards/individual-dashboards/indicator.disabled.test.ts
+++ b/tests/dashboards/individual-dashboards/indicator.disabled.test.ts
@@ -1,0 +1,16 @@
+import { test, expect } from "@playwright/test";
+import { SwipeHelper } from "../../helpers/touchHelpers";
+
+// Indicator disabled: indicator: false
+// Verifies: indicator element never appears
+
+test("indicator: disabled does not render", async ({ page }) => {
+  const dashboardPath = "/indicator-disabled";
+  await page.goto(dashboardPath);
+  await expect(page).toHaveURL(/\/0$/);
+
+  const haAppLayout = page.locator("[id='view']");
+  await SwipeHelper.swipeLeft(haAppLayout);
+
+  await expect(page.locator("#hsn-slide-indicator")).toHaveCount(0);
+});

--- a/tests/dashboards/individual-dashboards/indicator.duration.test.ts
+++ b/tests/dashboards/individual-dashboards/indicator.duration.test.ts
@@ -1,0 +1,19 @@
+import { test, expect } from "@playwright/test";
+import { SwipeHelper } from "../../helpers/touchHelpers";
+
+// Verifies indicator is removed after indicator_duration
+
+test("indicator: removed after duration", async ({ page }) => {
+  const dashboardPath = "/indicator-duration-default"; // for setting indicator_duration=1500
+
+  await page.goto(dashboardPath);
+  await expect(page).toHaveURL(/\/0$/);
+  const haAppLayout = page.locator("[id='view']");
+
+  await SwipeHelper.swipeLeft(haAppLayout);
+  const indicator = page.locator("#hsn-slide-indicator");
+  await expect(indicator).toBeVisible();
+
+  await page.waitForTimeout(1520);
+  await expect(indicator).toHaveCount(0);
+});

--- a/tests/dashboards/individual-dashboards/indicator.enabled.test.ts
+++ b/tests/dashboards/individual-dashboards/indicator.enabled.test.ts
@@ -1,0 +1,27 @@
+import { test, expect } from "@playwright/test";
+import { SwipeHelper } from "../../helpers/touchHelpers";
+
+test("indicator: shows and highlights active dot", async ({ page }) => {
+  const dashboardPath = "/indicator-enabled";
+  await page.goto(dashboardPath);
+  await expect(page).toHaveURL(/\/0$/);
+
+  const haAppLayout = page.locator("[id='view']");
+  await SwipeHelper.swipeLeft(haAppLayout);
+
+  // Indicator should exist within keep-alive time
+  const indicator = page.locator("#hsn-slide-indicator");
+  await expect(indicator).toBeVisible();
+
+  const dots = indicator.locator("span.hsn-dot");
+  await expect(dots).toHaveCountGreaterThan(0);
+
+  // Active dot should have transform scale(1.15)
+  const activeHasScale = await page.evaluate(() => {
+    const el = document.getElementById("hsn-slide-indicator");
+    if (!el) return false;
+    const dots = Array.from(el.children) as HTMLSpanElement[];
+    return dots.some(dot => (dot.style.transform || "").includes("scale(1.15)"));
+  });
+  expect(activeHasScale).toBeTruthy();
+});

--- a/tests/dashboards/individual-dashboards/indicator.resync-buffer.test.ts
+++ b/tests/dashboards/individual-dashboards/indicator.resync-buffer.test.ts
@@ -1,0 +1,30 @@
+import { test, expect } from "@playwright/test";
+import { SwipeHelper } from "../../helpers/touchHelpers";
+
+// Verifies single resync after animate_duration + indicator_resync_buffer
+
+test("indicator: single resync after duration + buffer", async ({ page }) => {
+  const dashboardPath = "/indicator-resync-default"; // for setting indicator_resync_buffer=50
+  const durationPlusBufferMs = 250; // 200 animate_duration + 50 resync_buffer
+
+  await page.goto(dashboardPath);
+  await expect(page).toHaveURL(/\/0$/);
+  const haAppLayout = page.locator("[id='view']");
+
+  // Swipe to the next view
+  await SwipeHelper.swipeLeft(haAppLayout);
+
+  // After resync window, active dot should indicate new index
+  await page.waitForTimeout(durationPlusBufferMs + 50);
+
+  const activeIndex = await page.evaluate(() => {
+    const el = document.getElementById("hsn-slide-indicator");
+    if (!el) return -1;
+    const dots = Array.from(el.children) as HTMLSpanElement[];
+    return dots.findIndex(d => (d.style.transform || "").includes("scale(1.15)"));
+  });
+  expect(activeIndex).toBeGreaterThanOrEqual(0);
+
+  // And URL should be on the next tab
+  await expect(page).toHaveURL(/\/1$/);
+});


### PR DESCRIPTION
Since this functionality was missing to me personally, I really wanted to have a view/swipe indicator like you have for other mobile apps https://github.com/zanna-37/hass-swipe-navigation/issues/128.

So I created this functionality myself.

Included is:
- ➕ `swipeIndicator.ts` which includes all the display logic for the indicator
- ✏️ `swipeManager.ts` hooked the functionality into `SwipeManager`
- ✏️` config.ts` three new configuration variables
- ➕ added playwright tests
- ✏️ `README.MD` included documentation for the three new settings

I tested this successfully in Chromium, the iOS Home Assistant app as well as Sonoff NSPanel Pro 86 (which is my initial starting point since I want to work with the display in Kiosk Mode i.e. no tabs/navigation and yes I have checked this with kiosk mode as well).

And it all looks nice I have to say myself (see indicator at the bottom of the view)😉 

Dark mode:
<video src='https://github.com/user-attachments/assets/062ccb15-2893-4576-a757-73c2ddcaf1aa' width=150>

Light mode:
<video src='https://github.com/user-attachments/assets/8f7cb91f-57a3-409f-80f5-5512cf5c7751' width=150>

