### PR TITLE
Add a polling fallback for early loading via frontend.extra_module_url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 -----
 
+## 🏷️ [Unreleased]
+
+### Fixed 🐛
+- Fix swipe navigation being silently dead on Home Assistant 2026.9: the dashboard shell mounts after the plugin loads and its `childList` MutationObservers no longer fire when the nodes are (re)added, so `SwipeManager.init()` never attached its listeners and `ConfigManager` kept a stale (null) panel, making navigation build `/null/<view>` URLs. Added a bounded polling fallback in `PageObject` so the added-callbacks still run, and made `ConfigManager.getPanel()` read the panel prefix fresh from the current route.
+
+
 ## 🏷️ [v1.16.0] - 2026-04-11
 [Full Changelog](https://github.com/zanna-37/hass-swipe-navigation/compare/v1.15.8...v1.16.0)
 

--- a/src/configManager.ts
+++ b/src/configManager.ts
@@ -29,6 +29,16 @@ class ConfigManager {
     return ConfigManager.currentConfig;
   }
   public static getPanel(): string | null {
+    // Read the panel prefix fresh from the current route, mirroring
+    // getCurrentViewName(). On the HA 2026.9 shell the dashboard mounts after
+    // the plugin has loaded, so the value cached by the early readConfig() run
+    // can be stale (null). Reading it here keeps navigateTo() from building
+    // "/null/<view>" URLs. The cached value is kept as a fallback.
+    const haPanelLovelace: (HTMLElement & PanelLovelaceCustom) | null = PageObjectManager.haPanelLovelace.getDomNode();
+    const panel = haPanelLovelace?.route?.prefix;
+    if (panel != null) {
+      ConfigManager.panel = panel.replace("/", "");
+    }
     return ConfigManager.panel;
   }
   public static getViews(): LovelaceViewConfig[] | null {

--- a/src/pageObject.ts
+++ b/src/pageObject.ts
@@ -2,12 +2,29 @@ import { Logger } from "./logger";
 import { LOG_TAG } from "./loggerUtils";
 
 
+// Polling fallback (see `startNodePollingFallback`). On the Home Assistant
+// 2026.9 shell some `childList` MutationObservers below no longer fire when the
+// dashboard nodes are (re)added, so the added-callbacks that features rely on to
+// (re)initialize would never run. We therefore also poll `getDomNode()` for a
+// bounded window and fire the callbacks if the target node appears without the
+// observer noticing.
+const NODE_POLL_INTERVAL_MS = 100;
+const NODE_POLL_MAX_ATTEMPTS = 50; // ~5 seconds
+
+
 class PageObject {
   private selectorPaths: string[];
   private domNodes: (Element | ShadowRoot | null)[] = [];
   private observers: (MutationObserver | null)[] = [];
   private domNodeAddedCallbacks: ((domNode: (Element | ShadowRoot)) => void)[] = [];
   private domNodeRemovedCallbacks: (() => void)[] = [];
+
+  // Last node for which the added-callbacks were delivered (by either the
+  // observers or the polling fallback). Used to avoid delivering the same node
+  // twice when both paths detect the same appearance.
+  private lastNotifiedNode: Element | ShadowRoot | null = null;
+  private nodePollTimeoutId: ReturnType<typeof setTimeout> | null = null;
+  private nodePollAttempts = 0;
 
   constructor(selectorsPaths: string[]) {
     this.selectorPaths = selectorsPaths;
@@ -26,6 +43,49 @@ class PageObject {
     // Push callbacks after creating the observers to avoid invoking the callback for the current
     // state of the DOM.
     this.domNodeAddedCallbacks.push(callback);
+
+    // Observers alone are not reliable on newer HA shells (see the note on the
+    // polling constants above), so back them up with a bounded poll.
+    this.startNodePollingFallback();
+  }
+
+  /**
+   * Bounded fallback for when the MutationObservers do not fire (observed on the
+   * HA 2026.9 shell). Periodically re-resolves the target node and, if it
+   * appears without having been reported by the observers, delivers the
+   * added-callbacks. Mirrors the observers' contract of not invoking callbacks
+   * for the node that is already present when the callback is registered.
+   */
+  private startNodePollingFallback(): void {
+    // Extend the polling window whenever a new consumer registers.
+    this.nodePollAttempts = 0;
+
+    if (this.nodePollTimeoutId != null) {
+      // A poll loop is already running; the reset above is enough.
+      return;
+    }
+
+    // Baseline: treat the currently present node (if any) as already notified so
+    // the poll only fires for nodes that appear from now on.
+    this.lastNotifiedNode = this.getDomNode();
+    this.scheduleNodePoll();
+  }
+
+  private scheduleNodePoll(): void {
+    this.nodePollTimeoutId = setTimeout(() => {
+      this.nodePollTimeoutId = null;
+      this.nodePollAttempts++;
+
+      const currentNode = this.getDomNode();
+      if (currentNode != null && currentNode !== this.lastNotifiedNode) {
+        Logger.logd(LOG_TAG, "DOM node detected via polling fallback: \"" + currentNode.nodeName.toLowerCase() + "\".");
+        this.invokeDomNodeAddedCallbacks(currentNode);
+      }
+
+      if (this.nodePollAttempts < NODE_POLL_MAX_ATTEMPTS) {
+        this.scheduleNodePoll();
+      }
+    }, NODE_POLL_INTERVAL_MS);
   }
 
   public toString(): string {
@@ -139,6 +199,8 @@ class PageObject {
   }
 
   private invokeDomNodeAddedCallbacks(domNode: Element | ShadowRoot): void {
+    // Record the node so the polling fallback does not deliver it a second time.
+    this.lastNotifiedNode = domNode;
     for (const callback of this.domNodeAddedCallbacks) {
       callback(domNode);
     }


### PR DESCRIPTION
## Symptom (Home Assistant 2026.9)

When the plugin is loaded early (the standard `frontend: extra_module_url` install), on HA **2026.9**:

- **Swipe does nothing at all** — no touch/mouse listeners are ever attached, so swiping is silently dead.
- When listeners *are* forced to attach, navigation is still broken: the plugin builds a **`/null/<view>`** URL and the view never changes.

## Root cause

The dashboard shell now mounts **after** the plugin script has run, and the per-path `childList` MutationObservers created by `PageObject` (`createNodeObserversFrom`, `subtree: false` on each path element) **do not fire** when those shell nodes are (re)added on the 2026.9 shell. Everything that is read/attached **once** at early load and relies on those added-callbacks to refresh therefore stays stale:

1. **`SwipeManager.init()`** runs once at startup. At that moment the view container (`hui-root`'s shadow `div` → `haAppLayout`, and `#view` → `haAppLayoutView`) does **not** exist yet, so `getDomNode()` returns `null` and the touch/mouse listeners are never attached. The `haAppLayout.addDomNodeAddedCallback(() => SwipeManager.init())` in `main.ts` never re-fires, so `init()` never re-runs.

2. **`ConfigManager.readConfig()`** also runs once early. At that moment `haPanelLovelace.route?.prefix` is `null`, so `ConfigManager.panel` is never set (stays `null`). The `huiRoot.addDomNodeAddedCallback(() => readConfig())` never re-fires either. Later `navigateTo()` builds `targetUrl = "/" + panelName + "/" + viewName` with `panelName === null` → `/null/<view>`.

For contrast, `getCurrentViewName()` / `getCurrentViewIndex()` keep working because they read `haPanelLovelace.route.path` **fresh** at call time rather than from a cached field.

### Evidence (captured live on HA 2026.9 with temporary probes)

At early load, `init()`'s `haAppLayout.getDomNode()` returned `null` (empty). After a real left-swipe on a view:

```
pointerStart
getNext views=6 activeIdx=0
navigateTo panel=null view=cucina url=/null/cucina
```

## Fix

- **`src/pageObject.ts`** — add a **bounded polling fallback** (~50 × 100 ms) that, after the observers are set up, re-resolves the target node and delivers the added-callbacks if the node appears without the observer noticing. A `lastNotifiedNode` guard makes sure the observer path and the poll path never deliver the same appearance twice, and the baseline is seeded with the currently-present node so a freshly registered callback is not fired for the current DOM state (matching the existing observer contract). This centrally restores **both** the `init()` re-run and the `readConfig()` re-run when the dashboard mounts, so it also fixes any other consumer of `addDomNodeAddedCallback`.
- **`src/configManager.ts`** — `getPanel()` now reads `route?.prefix` **fresh** from the current route (mirroring `getCurrentViewName()`) and updates the cached `panel`, so navigation never uses a stale `null` panel and never produces `/null/<view>`.

The change is backward compatible: on shells where the observers fire, the poll simply never observes a missed transition and the guard suppresses duplicate delivery; the poll is bounded and self-terminating.

## Testing

- `npm run build` succeeds and regenerates `dist/swipe-navigation.js`.
- `npx eslint src` passes.
- `tsc` (via the rollup TypeScript plugin) compiles cleanly; no `any` introduced.
- The Playwright/Docker E2E suite was **not** run here: it needs the full `docker-compose.test.yml` stack (a Home Assistant container + Playwright browser downloads), which was impractical in this environment. No test, config, or Docker files were changed, so the suite is unaffected. The build has been verified on a live HA 2026.9 Hub.